### PR TITLE
Feat/add status update to devices and servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore redis binary dump (dump.rdb) files
+
+*.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "bootsnap", require: false
 gem 'httparty'
 gem 'pry', '~> 0.14.2'
 gem 'rubocop', '~> 1.62', require: false
+gem 'sidekiq-cron'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'httparty'
 gem 'pry', '~> 0.14.2'
 gem 'rubocop', '~> 1.62', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,11 @@ GEM
     dotenv (3.1.0)
     drb (2.2.1)
     erubi (1.12.0)
+    et-orbi (1.2.9)
+      tzinfo
+    fugit (1.10.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     httparty (0.21.0)
@@ -162,6 +167,7 @@ GEM
       stringio
     puma (6.4.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.9.1)
     rack-session (2.0.0)
@@ -204,6 +210,8 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    redis-client (0.21.0)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -222,6 +230,15 @@ GEM
     rubocop-ast (1.31.2)
       parser (>= 3.3.0.4)
     ruby-progressbar (1.13.0)
+    sidekiq (7.2.2)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.19.0)
+    sidekiq-cron (1.12.0)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -272,6 +289,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   rubocop (~> 1.62)
+  sidekiq-cron
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -123,6 +126,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -260,6 +264,7 @@ DEPENDENCIES
   bootsnap
   debug
   dotenv
+  httparty
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/jobs/update_store_devices_and_servers_statuses_job.rb
+++ b/app/jobs/update_store_devices_and_servers_statuses_job.rb
@@ -1,0 +1,9 @@
+class UpdateStoreDevicesAndServersStatusesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Device.all.each(&:query_status)
+    Server.all.each(&:query_status)
+    Store.all.each(&:query_status)
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -2,4 +2,23 @@ class Device < ApplicationRecord
   belongs_to :store, dependent: :destroy
   validates :category, :status, presence: true
   validates :category, uniqueness: { scope: :store_id }
+
+  def query_status
+    if status == 'ok'
+      might_disconnect
+    else
+      might_connect
+    end
+    update(last_checked: Time.zone.now.to_datetime)
+  end
+
+  private
+
+  def might_disconnect
+    update(status: 'error') if rand(100) >= 95
+  end
+
+  def might_connect
+    update(status: 'ok') if rand(100) >= 65
+  end
 end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -1,5 +1,24 @@
+require "net/http"
 class Server < ApplicationRecord
   belongs_to :store, dependent: :destroy
   validates :category, :status, presence: true
   validates :category, uniqueness: { scope: :store_id }
+
+  def query_status
+    server_online = up?(url)
+    if server_online
+      status == 'ok' ? update(last_checked: Time.zone.now.to_datetime) : update(status: 'ok', last_checked: Time.zone.now.to_datetime)
+    else
+      status == 'error' ? update(last_checked: Time.zone.now.to_datetime) : update(status: 'error', last_checked: Time.zone.now.to_datetime)
+    end
+  end
+
+  private
+
+  def up?(server)
+    response = HTTParty.get(server)
+    response.code == 200
+  rescue Errno::ECONNREFUSED
+    false
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -17,4 +17,14 @@ class Store < ApplicationRecord
   def database
     servers.find_by(category: 'database')
   end
+
+  def query_status
+    if printer.status == 'ok' && servers.all? { |server| server.status == 'ok' }
+      status == 'ok' ? update(last_checked: Time.zone.now.to_datetime) : update(status: 'ok', last_checked: Time.zone.now.to_datetime)
+    elsif printer.status == 'error' && servers.all? { |server| server.status == 'error' }
+      status == 'error' ? update(last_checked: Time.zone.now.to_datetime) : update(status: 'error', last_checked: Time.zone.now.to_datetime)
+    else
+      status == 'warning' ? update(last_checked: Time.zone.now.to_datetime) : update(status: 'warning', last_checked: Time.zone.now.to_datetime)
+    end
+  end
 end

--- a/app/views/stores/_store.html.erb
+++ b/app/views/stores/_store.html.erb
@@ -37,6 +37,6 @@
         </li>
     </ul>
     <div class="card-body text-center">
-        <%= link_to "Ir a #{store.short_name}", store.website_url, class: "btn #{color_button_main(store.short_name)}" %>
+        <%= link_to "Ir a #{store.short_name}", store.web.url, class: "btn #{color_button_main(store.short_name)}", target: "_blank" %>
     </div>
   </div>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,4 @@
+schedule_file = 'config/schedule.yml'
+if File.exist?(schedule_file) && Sidekiq.server?
+   Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,3 @@
+status_update_job:
+   cron: "*/30 * * * * *"
+   class: "UpdateStoreDevicesAndServersStatusesJob"

--- a/db/migrate/20240321163717_change_website_url_from_store_to_server.rb
+++ b/db/migrate/20240321163717_change_website_url_from_store_to_server.rb
@@ -1,0 +1,6 @@
+class ChangeWebsiteUrlFromStoreToServer < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :stores, :website_url, :text
+    add_column :servers, :url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_21_055743) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_21_163717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_055743) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "store_id"
+    t.text "url"
     t.index ["store_id"], name: "index_servers_on_store_id"
   end
 
@@ -43,7 +44,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_055743) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "short_name"
-    t.text "website_url"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,6 @@ Store.create([
                  category: 'restaurant',
                  status: 'ok',
                  last_checked: Time.zone.now.to_datetime,
-                 website_url: 'https://kao.cl/',
                  photo_url: 'https://images.unsplash.com/photo-1552914343-54bcc3ba07f8?q=80&w=1984&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
                },
                {
@@ -25,7 +24,6 @@ Store.create([
                  category: 'restaurant',
                  status: 'ok',
                  last_checked: Time.zone.now.to_datetime,
-                 website_url: 'https://guacamole.cl/',
                  photo_url: 'https://images.unsplash.com/photo-1582169296194-e4d644c48063?q=80&w=2000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
                }
              ])
@@ -48,24 +46,28 @@ Server.create([
                   store_id: 1,
                   category: 'web',
                   status: 'ok',
+                  url: 'https://kao.cl/',
                   last_checked: Time.zone.now.to_datetime
                 },
                 {
                   store_id: 2,
                   category: 'web',
                   status: 'ok',
+                  url: 'https://guacamole.cl/',
                   last_checked: Time.zone.now.to_datetime
                 },
                 {
                   store_id: 1,
                   category: 'database',
                   status: 'ok',
+                  url: 'https://kao.cl/',
                   last_checked: Time.zone.now.to_datetime
                 },
                 {
                   store_id: 2,
                   category: 'database',
                   status: 'ok',
+                  url: 'https://guacamole.cl/',
                   last_checked: Time.zone.now.to_datetime
                 }
               ])


### PR DESCRIPTION
Añadidos métodos de consulta (actualización de estado) para Tiendas, Dispositivos y Servidores:
- Dispositivos: cada 30 segundos se actualizan, con un 5% de probabilidades de desconectarse si está conectado (si su estado está 'ok'), y 35% de probabilidades de volver en línea si está desconectado (si su estado es 'error')
- Servidores: se consulta si las direcciones de las tiendas (ingresadas a través de seeds) retornan estado 200
- Tiendas: se actualiza el estado según si sus dispositivos y servidores están ok o con error

Añadidos Jobs cronológicos usando Sidekiq-cron y se añaden métodos de actualización de estado cada 30 segundos